### PR TITLE
Chop mapping with coefficients smaller than threshold

### DIFF
--- a/groupedFermionicOperator.py
+++ b/groupedFermionicOperator.py
@@ -140,6 +140,9 @@ class groupedFermionicOperator:
         """
         
         mapping = self.mapping
+        for i in mapping:
+            mapping[i] = mapping[i].chop(threshold=self.THRESHOLD)
+
         qubitOp = WeightedPauliOperator(paulis=[])
         for k, w in self.grouped_op.items():
             if np.ndim(k) == 1: ## one-e-term


### PR DESCRIPTION
Chop each `WeightedPauliOperator` in `mapping` of the `to_paulis` method with Pauli term coefficients smaller than the given threshold.